### PR TITLE
install icepyx and captoolkit from master branches

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -65,6 +65,6 @@ dependencies:
   - xarray
   - yaml
   - zarr
-#  - pip:
-#    - git+https://github.com/icesat2py/icepyx.git@2a0fc77ca135d9e41448f1afd82d5c2038ec9bce
-#    - git+https://github.com/fspaolo/captoolkit.git@03bb4e01790451e557dc91a8e5a11e898e0b7fc9
+  - pip:
+    - git+https://github.com/icesat2py/icepyx.git@master
+    - git+https://github.com/fspaolo/captoolkit.git@master

--- a/start
+++ b/start
@@ -1,7 +1,8 @@
 #!/bin/bash -l
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
-pip install -e git+https://github.com/icesat2py/icepyx.git#egg=icepyx --src /srv/icesat2py
+# No longer install development version, it's included in environment.yml
+#pip install -e git+https://github.com/icesat2py/icepyx.git#egg=icepyx --src /srv/icesat2py
 
 # ==== ONLY EDIT WITHIN THIS BLOCK =====
 exec "$@"


### PR DESCRIPTION
@JessicaS11 and @fspaolo This PR will ensure your packages are in the default environment during the hackweek. 

If you prefer to use a specific tag/release instead of 'master' let me know. If you make changes to your master branch or release a new version this week we'd have to rebuild the image.  