### PR TITLE
rebuild with latest pangeo base, python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/base-image:2020.04.07
+FROM pangeo/base-image:2020.05.29

--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,10 @@ channels:
   - conda-forge
 dependencies:
 # Core pangeo jupyterhub requirements
-  - python=3.8
-  - pangeo-notebook=2020.04.04
+  - python=3.7
+  - pangeo-notebook=2020.05.29
   - python-graphviz
-  - pip=20.0
+  - pip
 # Additional libraries (alphabetical order)
   - astropy
   - awscli


### PR DESCRIPTION
possible fix for failing builds with ML-libraries: https://github.com/ICESAT-2HackWeek/jupyter-image-2020/pull/9 https://github.com/ICESAT-2HackWeek/jupyter-image-2020/pull/10 

Seems ML libraries on conda-forge still aren't compatible with python 3.8